### PR TITLE
Copyedit capture-area text

### DIFF
--- a/src/app/capture-area/capture-area.component.html
+++ b/src/app/capture-area/capture-area.component.html
@@ -1,1 +1,1 @@
-<p>Focus here(click) and press the shortcut key you want</p>
+<p>Focus this area (click here) and press the shortcut key you want</p>

--- a/src/app/capture-area/capture-area.component.html
+++ b/src/app/capture-area/capture-area.component.html
@@ -1,1 +1,1 @@
-<p>Focus this area (click here) and press the shortcut key you want</p>
+<p>Focus this area (click here) and press the shortcut key(s) you want</p>


### PR DESCRIPTION
Fixes a typo (no space between “here” and parens) and expands instructions slightly.