### PR TITLE
Correct 3 typos

### DIFF
--- a/src/app/option/option.component.html
+++ b/src/app/option/option.component.html
@@ -1,4 +1,4 @@
-<h2>Option</h2>
+<h2>Options</h2>
 <fieldset>
   <legend>Choose format:</legend>
 
@@ -6,11 +6,12 @@
     <div>
       <input type="radio" id="symbols-and-chars" formControlName="symbols" [value]="symbolsFormats.SymbolsAndCharacters"
              checked>
-      <label for="symbols-and-chars">Symbols and Characters (<kbd>⇧ Shift</kbd>&nbsp;<kbd>⌘ Command</kbd>&nbsp;<kbd>⌫ Delete</kbd>…)</label>
+      <label for="symbols-and-chars">Symbols and Characters (<kbd>⇧ Shift</kbd>&nbsp;<kbd>⌘ Command</kbd>&nbsp;<kbd>⌫
+          Delete</kbd>…)</label>
     </div>
 
     <div>
-      <input type="radio" id="only-chars"  formControlName="symbols" [value]="symbolsFormats.OnlyCharacters">
+      <input type="radio" id="only-chars" formControlName="symbols" [value]="symbolsFormats.OnlyCharacters">
       <label for="only-chars">Only Characters (<kbd>Shift</kbd>&nbsp;<kbd>Command</kbd>&nbsp;<kbd>Delete</kbd>…)</label>
     </div>
 

--- a/src/app/shortcuts-render/shortcuts-render.component.html
+++ b/src/app/shortcuts-render/shortcuts-render.component.html
@@ -1,10 +1,10 @@
-<h2>Source Code</h2>
+<h2>Source code</h2>
 <div class="highlight">
   <pre><code>{{code}}</code></pre>
   <app-clipboard-copy [value]="code"></app-clipboard-copy>
 </div>
 
-<h2>Preview</h2>
+<h2>Previews</h2>
 
 <h3>Github</h3>
 
@@ -29,6 +29,3 @@
     </ng-container>
   </ng-container>
 </p>
-
-
-


### PR DESCRIPTION
- “Source code” should have a lowercase “c” on “code”
- “Previews” and “Options” should be plural