### PR TITLE
Alter rendering of spaces

### DIFF
--- a/src/app/shortcuts-render/shortcuts-render.component.ts
+++ b/src/app/shortcuts-render/shortcuts-render.component.ts
@@ -109,10 +109,10 @@ export class ShortcutsRenderComponent implements OnChanges {
         } else {
           c = key!.name[0]
         }
-        s = key!.name?.[1] ? `${key!.name?.[1]} ` : '';
+        s = key!.name?.[1] ? `${key!.name?.[1]}` : '';
         switch (this.option?.symbols) {
           case SymbolsFormat.SymbolsAndCharacters:
-            return `${s}${c}`;
+            return `${s}${s ? ' ' : ''}${c}`;
           case SymbolsFormat.OnlyCharacters:
             return c;
           case SymbolsFormat.OnlySymbols:

--- a/src/app/shortcuts-render/shortcuts-render.component.ts
+++ b/src/app/shortcuts-render/shortcuts-render.component.ts
@@ -120,7 +120,7 @@ export class ShortcutsRenderComponent implements OnChanges {
             return s ? s : c;
         }
       })
-    this.code = this.symbolizeKeys.map(s => `<kbd>${s}</kbd>`).join(this.option?.separator ? " + " : " ");
+    this.code = this.symbolizeKeys.map(s => `<kbd>${s}</kbd>`).join(this.option?.separator ? " + " : "");
   }
 
 }


### PR DESCRIPTION
Removes the space between elements when the “+” is not used.

Also, moves the rendering of the space after the symbol, conditionally, to the “switch” block.

Previously, choosing “Symbols only” resulted in spaces after the symbols, inside the elements:
`<kbd>⇧ </kbd> <kbd>⌘ </kbd> <kbd>P</kbd>`

Now, choosing “Symbols only” results in:
`<kbd>⇧</kbd><kbd>⌘</kbd><kbd>P</kbd>`

Apologies if the JS syntax I’ve chosen is not the most appropriate.